### PR TITLE
Balance Peltier cooler usage via session-based alternation

### DIFF
--- a/config/desired_states.py
+++ b/config/desired_states.py
@@ -28,10 +28,11 @@ desired_temperature_map = {
         ], key=lambda x: x[0]),
 }
 
-cooler_active_diff_thresholds = {
-    "N. Peltier Upper": -0.5,
-    "N. Peltier Lower": 0.0,
-}
+# Shared thresholds for staged cooling.  Both coolers use the same levels so
+# that neither is systematically preferred.  The evaluator alternates which
+# cooler is "primary" (activated first) each session to balance wear.
+COOLER_PRIMARY_THRESHOLD = 0.0   # Activate the primary cooler
+COOLER_SECONDARY_THRESHOLD = -0.5  # Activate both coolers
 
 heater_active_diff_thresholds = {
     "N. UV": 0.8,

--- a/evaluators/cooler_heater.py
+++ b/evaluators/cooler_heater.py
@@ -7,10 +7,40 @@ from config.device_aliases import air_meter_aliases, cooler_aliases, pump_alias,
 from helpers.extract_data import extract_humidities, extract_temperatures, extract_pump_switch_state,\
     extract_pump_element_switch_states, extract_current_humidity
 from config.desired_states import desired_temperature, desired_min_humidity,\
-    desired_temperature_map, cooler_active_diff_thresholds, heater_active_diff_thresholds,\
-    ext_fan_diff_thresholds
+    desired_temperature_map, COOLER_PRIMARY_THRESHOLD, COOLER_SECONDARY_THRESHOLD,\
+    heater_active_diff_thresholds, ext_fan_diff_thresholds
+from helpers.cooler_balance import get_primary_cooler, rotate_primary_cooler, DEFAULT_STATE_PATH
 
 logger = logging.getLogger(__name__)
+
+
+def get_balanced_cooler_desired_state(
+    max_diff_temp: float,
+    current_switch_states: dict,
+    state_path: str = DEFAULT_STATE_PATH,
+) -> dict:
+    """Return desired on/off state for each cooler, alternating the primary cooler.
+
+    When light cooling is needed (diff within the primary threshold) only the
+    current primary cooler activates.  When heavy cooling is needed (diff at or
+    below the secondary threshold) both activate.  Each time a cooling session
+    ends the primary role passes to the other cooler, balancing wear.
+    """
+    was_cooling = any(current_switch_states.get(alias, False) for alias in cooler_aliases)
+
+    if max_diff_temp > COOLER_PRIMARY_THRESHOLD:
+        desired = {alias: False for alias in cooler_aliases}
+    elif max_diff_temp <= COOLER_SECONDARY_THRESHOLD:
+        desired = {alias: True for alias in cooler_aliases}
+    else:
+        primary = get_primary_cooler(state_path)
+        desired = {alias: alias == primary for alias in cooler_aliases}
+
+    is_cooling = any(desired.values())
+    if was_cooling and not is_cooling:
+        rotate_primary_cooler(state_path)
+
+    return desired
 
 
 def uv_time_based_on(alias: str, current_datetime: datetime.datetime):
@@ -68,7 +98,7 @@ def evaluate_desired_cooler_states(current_datetime: datetime.datetime, data):
     max_diff_temp = pre_max_diff_temp - (1.0 if ext_fan_is_on else 0.0)
 
     # Decide pump-safe Cooler and Heater state
-    cooler_prime_desired_state = { alias: max_diff_temp <= cooler_active_diff_thresholds[alias] for alias in cooler_aliases}
+    cooler_prime_desired_state = get_balanced_cooler_desired_state(max_diff_temp, pump_element_switch_states)
     heater_prime_desired_state = { alias: max_diff_temp >= heater_active_diff_thresholds[alias] or uv_time_based_on(alias, current_datetime) for alias in heater_aliases}
 
     # Override Disable Heater when Ext Fan is on

--- a/helpers/cooler_balance.py
+++ b/helpers/cooler_balance.py
@@ -1,0 +1,46 @@
+import json
+import logging
+import os
+
+from config.device_aliases import cooler_aliases
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATE_PATH = os.path.join("data", "cooler_balance_state.json")
+
+
+def get_primary_cooler(state_path: str = DEFAULT_STATE_PATH) -> str:
+    """Return which cooler is currently the primary (activates first).
+
+    Falls back to the first alias in cooler_aliases when the state file is
+    missing, unreadable, or contains an unknown alias.
+    """
+    try:
+        with open(state_path, "r") as f:
+            state = json.load(f)
+        primary = state.get("primary")
+        if primary in cooler_aliases:
+            return primary
+    except (OSError, json.JSONDecodeError, KeyError):
+        pass
+    return cooler_aliases[0]
+
+
+def rotate_primary_cooler(state_path: str = DEFAULT_STATE_PATH) -> None:
+    """Rotate the primary cooler to the next one in the list and persist."""
+    current = get_primary_cooler(state_path)
+    idx = cooler_aliases.index(current) if current in cooler_aliases else 0
+    next_primary = cooler_aliases[(idx + 1) % len(cooler_aliases)]
+    try:
+        directory = os.path.dirname(state_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        with open(state_path, "w") as f:
+            json.dump({"primary": next_primary}, f)
+        logger.info(
+            "Cooler balance: rotated primary from %s to %s", current, next_primary
+        )
+    except OSError:
+        logger.warning(
+            "Cooler balance: failed to save state to %s", state_path
+        )

--- a/tests/test_config/test_desired_states.py
+++ b/tests/test_config/test_desired_states.py
@@ -4,8 +4,8 @@ from config.desired_states import (
     desired_temperature, desired_min_humidity,
     time_in_range, get_between_time, to_second_stamp, stamp_diff,
     desired_temperature_map, PLUG_TASK_PRIORITY, PLUG_DEFAULT_DESIRED_STATES,
-    cooler_active_diff_thresholds, heater_active_diff_thresholds,
-    ext_fan_diff_thresholds,
+    COOLER_PRIMARY_THRESHOLD, COOLER_SECONDARY_THRESHOLD,
+    heater_active_diff_thresholds, ext_fan_diff_thresholds,
 )
 from config.device_aliases import (
     cooler_aliases, heater_aliases, extfan_aliases,
@@ -126,9 +126,12 @@ class TestPlugConstants:
         for alias in PLUG_TASK_PRIORITY:
             assert alias in PLUG_DEFAULT_DESIRED_STATES
 
+    def test_cooler_thresholds_ordered(self):
+        # Secondary threshold must be strictly lower than primary threshold so
+        # staged cooling makes sense.
+        assert COOLER_SECONDARY_THRESHOLD < COOLER_PRIMARY_THRESHOLD
+
     def test_threshold_dicts_match_aliases(self):
-        for alias in cooler_aliases:
-            assert alias in cooler_active_diff_thresholds
         for alias in heater_aliases:
             assert alias in heater_active_diff_thresholds
         for alias in extfan_aliases:

--- a/tests/test_evaluators/test_cooler_heater.py
+++ b/tests/test_evaluators/test_cooler_heater.py
@@ -1,9 +1,12 @@
+import json
 import pytest
 import datetime
 from evaluators.cooler_heater import (
     uv_time_based_on, ext_fan_state, evaluate_desired_cooler_states,
+    get_balanced_cooler_desired_state,
 )
-from config.device_aliases import uv_aliases
+from config.device_aliases import cooler_aliases, uv_aliases
+from config.desired_states import COOLER_PRIMARY_THRESHOLD, COOLER_SECONDARY_THRESHOLD
 
 
 class TestUvTimeBasedOn:
@@ -80,6 +83,112 @@ class TestExtFanState:
         values = {"Temperature": 0, "Humidity": -15}
         thresholds = {"Temperature": -1.0, "Humidity": -10}
         assert ext_fan_state(dt, values, thresholds) is False
+
+
+class TestGetBalancedCoolerDesiredState:
+    """Tests for the session-based cooler alternation logic."""
+
+    @pytest.fixture
+    def state_path(self, tmp_path):
+        return str(tmp_path / "cooler_balance_state.json")
+
+    def _set_primary(self, state_path, alias):
+        with open(state_path, "w") as f:
+            json.dump({"primary": alias}, f)
+
+    def test_no_cooling_both_off(self, state_path):
+        diff = COOLER_PRIMARY_THRESHOLD + 0.1  # above primary threshold → no cooling
+        current = {alias: False for alias in cooler_aliases}
+        result = get_balanced_cooler_desired_state(diff, current, state_path)
+        assert all(v is False for v in result.values())
+
+    def test_heavy_cooling_both_on(self, state_path):
+        diff = COOLER_SECONDARY_THRESHOLD - 0.1  # at or below secondary threshold
+        current = {alias: True for alias in cooler_aliases}
+        result = get_balanced_cooler_desired_state(diff, current, state_path)
+        assert all(v is True for v in result.values())
+
+    def test_light_cooling_only_primary_on(self, state_path):
+        # Diff between secondary and primary thresholds → only primary runs
+        diff = (COOLER_PRIMARY_THRESHOLD + COOLER_SECONDARY_THRESHOLD) / 2
+        primary = cooler_aliases[0]
+        self._set_primary(state_path, primary)
+        current = {alias: False for alias in cooler_aliases}
+        result = get_balanced_cooler_desired_state(diff, current, state_path)
+        assert result[primary] is True
+        for alias in cooler_aliases:
+            if alias != primary:
+                assert result[alias] is False
+
+    def test_light_cooling_uses_second_alias_as_primary(self, state_path):
+        diff = (COOLER_PRIMARY_THRESHOLD + COOLER_SECONDARY_THRESHOLD) / 2
+        primary = cooler_aliases[1]
+        self._set_primary(state_path, primary)
+        current = {alias: False for alias in cooler_aliases}
+        result = get_balanced_cooler_desired_state(diff, current, state_path)
+        assert result[primary] is True
+        for alias in cooler_aliases:
+            if alias != primary:
+                assert result[alias] is False
+
+    def test_session_end_rotates_primary(self, state_path):
+        """When cooling stops (was on, now off) the primary should rotate."""
+        first_primary = cooler_aliases[0]
+        self._set_primary(state_path, first_primary)
+        # Session was active (one cooler was on)
+        current = {cooler_aliases[0]: True, **{a: False for a in cooler_aliases[1:]}}
+        diff = COOLER_PRIMARY_THRESHOLD + 0.1  # no longer cooling
+        get_balanced_cooler_desired_state(diff, current, state_path)
+        # Primary should have rotated
+        with open(state_path) as f:
+            saved = json.load(f)
+        assert saved["primary"] == cooler_aliases[1]
+
+    def test_no_rotation_when_cooling_continues(self, state_path):
+        """Primary should not rotate while a cooling session is still active."""
+        first_primary = cooler_aliases[0]
+        self._set_primary(state_path, first_primary)
+        current = {cooler_aliases[0]: True, **{a: False for a in cooler_aliases[1:]}}
+        # Still light cooling
+        diff = (COOLER_PRIMARY_THRESHOLD + COOLER_SECONDARY_THRESHOLD) / 2
+        get_balanced_cooler_desired_state(diff, current, state_path)
+        with open(state_path) as f:
+            saved = json.load(f)
+        assert saved["primary"] == first_primary
+
+    def test_no_rotation_when_was_not_cooling(self, state_path):
+        """Primary should not rotate when there was no prior cooling session."""
+        first_primary = cooler_aliases[0]
+        self._set_primary(state_path, first_primary)
+        current = {alias: False for alias in cooler_aliases}
+        diff = COOLER_PRIMARY_THRESHOLD + 0.1  # no cooling needed
+        get_balanced_cooler_desired_state(diff, current, state_path)
+        with open(state_path) as f:
+            saved = json.load(f)
+        assert saved["primary"] == first_primary
+
+    def test_at_primary_threshold_boundary(self, state_path):
+        """Exactly at the primary threshold → only primary cooler activates."""
+        diff = COOLER_PRIMARY_THRESHOLD  # <= threshold → light cooling
+        primary = cooler_aliases[0]
+        self._set_primary(state_path, primary)
+        current = {alias: False for alias in cooler_aliases}
+        result = get_balanced_cooler_desired_state(diff, current, state_path)
+        assert result[primary] is True
+
+    def test_at_secondary_threshold_boundary(self, state_path):
+        """Exactly at the secondary threshold → both coolers activate."""
+        diff = COOLER_SECONDARY_THRESHOLD
+        current = {alias: True for alias in cooler_aliases}
+        result = get_balanced_cooler_desired_state(diff, current, state_path)
+        assert all(v is True for v in result.values())
+
+    def test_returns_all_cooler_aliases(self, state_path):
+        """Result dict must contain an entry for every cooler alias."""
+        diff = COOLER_PRIMARY_THRESHOLD + 0.1
+        current = {alias: False for alias in cooler_aliases}
+        result = get_balanced_cooler_desired_state(diff, current, state_path)
+        assert set(result.keys()) == set(cooler_aliases)
 
 
 class TestEvaluateDesiredCoolerStates:

--- a/tests/test_helpers/test_cooler_balance.py
+++ b/tests/test_helpers/test_cooler_balance.py
@@ -1,0 +1,78 @@
+import json
+import os
+import pytest
+
+from config.device_aliases import cooler_aliases
+from helpers.cooler_balance import get_primary_cooler, rotate_primary_cooler
+
+
+class TestGetPrimaryCooler:
+    def test_returns_first_alias_when_no_file(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        result = get_primary_cooler(state_path)
+        assert result == cooler_aliases[0]
+
+    def test_reads_known_primary_from_file(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        for alias in cooler_aliases:
+            with open(state_path, "w") as f:
+                json.dump({"primary": alias}, f)
+            assert get_primary_cooler(state_path) == alias
+
+    def test_falls_back_on_invalid_json(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        with open(state_path, "w") as f:
+            f.write("not-json")
+        assert get_primary_cooler(state_path) == cooler_aliases[0]
+
+    def test_falls_back_on_unknown_alias(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        with open(state_path, "w") as f:
+            json.dump({"primary": "N. Unknown Device"}, f)
+        assert get_primary_cooler(state_path) == cooler_aliases[0]
+
+    def test_falls_back_when_primary_key_missing(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        with open(state_path, "w") as f:
+            json.dump({"other": "value"}, f)
+        assert get_primary_cooler(state_path) == cooler_aliases[0]
+
+
+class TestRotatePrimaryCooler:
+    def test_rotates_to_next_alias(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        with open(state_path, "w") as f:
+            json.dump({"primary": cooler_aliases[0]}, f)
+        rotate_primary_cooler(state_path)
+        assert get_primary_cooler(state_path) == cooler_aliases[1]
+
+    def test_wraps_around_to_first(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        with open(state_path, "w") as f:
+            json.dump({"primary": cooler_aliases[-1]}, f)
+        rotate_primary_cooler(state_path)
+        assert get_primary_cooler(state_path) == cooler_aliases[0]
+
+    def test_creates_directory_if_missing(self, tmp_path):
+        state_path = str(tmp_path / "subdir" / "state.json")
+        rotate_primary_cooler(state_path)
+        assert os.path.exists(state_path)
+
+    def test_handles_write_error_gracefully(self, tmp_path):
+        # Point at a path whose parent is actually a file so os.makedirs fails
+        blocker = tmp_path / "blocker"
+        blocker.write_text("file")
+        state_path = str(blocker / "state.json")
+        # Should not raise
+        rotate_primary_cooler(state_path)
+
+    def test_full_rotation_cycle(self, tmp_path):
+        state_path = str(tmp_path / "state.json")
+        seen = []
+        for _ in range(len(cooler_aliases)):
+            seen.append(get_primary_cooler(state_path))
+            rotate_primary_cooler(state_path)
+        # After a full cycle the primary returns to the first alias
+        assert get_primary_cooler(state_path) == cooler_aliases[0]
+        # Every alias appeared exactly once
+        assert sorted(seen) == sorted(cooler_aliases)


### PR DESCRIPTION
Previously, N. Peltier Lower had a less restrictive activation threshold
(0.0°C diff) than N. Peltier Upper (-0.5°C diff), causing Lower to run
during every cooling session while Upper only ran under heavier load.
Over time this creates predictably uneven wear, making replacement
scheduling difficult.

This change replaces the per-cooler thresholds with a shared pair of
staged thresholds (PRIMARY_THRESHOLD=0.0, SECONDARY_THRESHOLD=-0.5) and
introduces session-based alternation:

- When light cooling is needed (diff between thresholds), only the
  current "primary" cooler activates.
- When heavy cooling is needed (diff at/below secondary threshold), both
  coolers activate regardless of role.
- When a cooling session ends (both coolers transition from on→off), the
  primary role rotates to the other cooler for the next session.

The primary cooler state is persisted to data/cooler_balance_state.json
so alternation survives process restarts. The helper degrades gracefully
(defaults to the first alias) when the file is missing or unreadable.

Closes #1

https://claude.ai/code/session_01FAgZZCSvpUvNiWgrTRw196