### PR TITLE
Detect cooler frozen events and pause thermal systems for thawing

### DIFF
--- a/evaluators/cooler_heater.py
+++ b/evaluators/cooler_heater.py
@@ -82,8 +82,8 @@ def evaluate_desired_cooler_states(current_datetime: datetime.datetime, data):
     logger.debug("Temperatures: %s, desired_diffs: %s, pre_max_diff_temp: %.1f", temperatures, air_meter_desired_diffs, pre_max_diff_temp)
 
     # Detect cooler frozen condition
-    coolers_active = any(pump_element_switch_states.get(alias, False) for alias in cooler_aliases)
-    frozen_paused = check_cooler_frozen(current_datetime, coolers_active, max_temperature)
+    active_cooler_count = sum(1 for alias in cooler_aliases if pump_element_switch_states.get(alias, False))
+    frozen_paused = check_cooler_frozen(current_datetime, active_cooler_count, max_temperature)
 
     if frozen_paused:
         desired_humidity = desired_min_humidity(current_datetime)

--- a/helpers/cooler_frozen.py
+++ b/helpers/cooler_frozen.py
@@ -9,12 +9,23 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_STATE_PATH = os.path.join("data", "cooler_frozen_state.json")
 
-# How long coolers must be continuously active with no temperature drop
-# before declaring a freeze condition (minutes).
-FROZEN_DETECTION_MINUTES = 20
+# Detection window per number of active coolers (minutes).
+# More coolers → faster expected cooling → shorter detection window.
+FROZEN_DETECTION_MINUTES = {
+    1: 40,
+    2: 20,
+}
 
 # How long to pause all thermal systems to allow coolant to thaw (minutes).
 FROZEN_THAW_MINUTES = 90
+
+
+def _detection_minutes(active_cooler_count: int) -> int:
+    """Return the freeze-detection window for the given number of active coolers."""
+    return FROZEN_DETECTION_MINUTES.get(
+        active_cooler_count,
+        FROZEN_DETECTION_MINUTES[max(FROZEN_DETECTION_MINUTES)],
+    )
 
 
 def _load_state(state_path: str) -> dict:
@@ -38,16 +49,17 @@ def _save_state(state_path: str, state: dict) -> None:
 
 def check_cooler_frozen(
     current_datetime: datetime.datetime,
-    coolers_active: bool,
+    active_cooler_count: int,
     current_temperature: float,
     state_path: str = DEFAULT_STATE_PATH,
 ) -> bool:
     """Detect cooler freeze and manage the thaw pause cycle.
 
     Tracks temperature while coolers are running.  If temperature has not
-    dropped after ``FROZEN_DETECTION_MINUTES`` of continuous cooling the
-    coolant is assumed frozen and a thaw pause of ``FROZEN_THAW_MINUTES``
-    begins during which all thermal systems should be disabled.
+    dropped after a detection window (which varies with the number of active
+    coolers) the coolant is assumed frozen and a thaw pause of
+    ``FROZEN_THAW_MINUTES`` begins during which all thermal systems should
+    be disabled.
 
     Returns ``True`` when the system should be in a freeze-thaw pause
     (all thermal outputs off), ``False`` for normal operation.
@@ -71,7 +83,7 @@ def check_cooler_frozen(
         _save_state(state_path, state)
 
     # --- Not in pause – track cooling effectiveness ---
-    if not coolers_active:
+    if active_cooler_count == 0:
         # Cooling stopped, reset any tracking
         if state.get("cooling_started_at") is not None:
             _save_state(state_path, {})
@@ -79,17 +91,22 @@ def check_cooler_frozen(
 
     # Coolers are active – record or evaluate
     cooling_started_at = state.get("cooling_started_at")
-    if cooling_started_at is None:
-        # Cooling just started – begin tracking
+    stored_count = state.get("active_cooler_count")
+
+    if cooling_started_at is None or stored_count != active_cooler_count:
+        # Cooling just started, or the number of active coolers changed –
+        # (re-)start the detection window with the current baseline.
         state["cooling_started_at"] = current_datetime.isoformat()
         state["cooling_start_temp"] = current_temperature
+        state["active_cooler_count"] = active_cooler_count
         _save_state(state_path, state)
         return False
 
     started_dt = datetime.datetime.fromisoformat(cooling_started_at)
     elapsed = (current_datetime - started_dt).total_seconds() / 60.0
+    detection_window = _detection_minutes(active_cooler_count)
 
-    if elapsed < FROZEN_DETECTION_MINUTES:
+    if elapsed < detection_window:
         return False
 
     start_temp = state.get("cooling_start_temp", current_temperature)
@@ -97,9 +114,10 @@ def check_cooler_frozen(
     if current_temperature >= start_temp:
         # Temperature flat or rising despite active cooling – FROZEN
         logger.warning(
-            "Cooler frozen detected! Cooling active for %.1f min, "
+            "Cooler frozen detected! %d cooler(s) active for %.1f min (window %d min), "
             "start_temp=%.1f, current_temp=%.1f. Entering %d-min thaw pause.",
-            elapsed, start_temp, current_temperature, FROZEN_THAW_MINUTES,
+            active_cooler_count, elapsed, detection_window,
+            start_temp, current_temperature, FROZEN_THAW_MINUTES,
         )
         _save_state(state_path, {"frozen_at": current_datetime.isoformat()})
         return True

--- a/tests/test_evaluators/test_cooler_heater.py
+++ b/tests/test_evaluators/test_cooler_heater.py
@@ -302,7 +302,14 @@ class TestEvaluateDesiredCoolerStatesFrozen:
         args = mock_frozen.call_args
         # First positional arg: current_datetime
         assert args[0][0] == dt
-        # Second positional arg: coolers_active (Peltier Upper is ON in fixture)
-        assert args[0][1] is True
+        # Second positional arg: active_cooler_count (Peltier Upper is ON in fixture)
+        assert args[0][1] == 1
         # Third positional arg: max_temperature (max of 22.0, 20.0)
         assert args[0][2] == 22.0
+
+    @patch("evaluators.cooler_heater.check_cooler_frozen", return_value=True)
+    def test_frozen_passes_dual_count(self, mock_frozen, full_data):
+        full_data["plugs"]["v0"]["N. Peltier Lower"]["Switch"] = True
+        dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        evaluate_desired_cooler_states(dt, full_data)
+        assert mock_frozen.call_args[0][1] == 2

--- a/tests/test_helpers/test_cooler_frozen.py
+++ b/tests/test_helpers/test_cooler_frozen.py
@@ -5,7 +5,22 @@ from helpers.cooler_frozen import (
     check_cooler_frozen,
     FROZEN_DETECTION_MINUTES,
     FROZEN_THAW_MINUTES,
+    _detection_minutes,
 )
+
+
+class TestDetectionMinutes:
+    def test_single_cooler(self):
+        assert _detection_minutes(1) == FROZEN_DETECTION_MINUTES[1]
+
+    def test_dual_cooler(self):
+        assert _detection_minutes(2) == FROZEN_DETECTION_MINUTES[2]
+
+    def test_single_longer_than_dual(self):
+        assert FROZEN_DETECTION_MINUTES[1] > FROZEN_DETECTION_MINUTES[2]
+
+    def test_unknown_count_uses_max_key(self):
+        assert _detection_minutes(5) == FROZEN_DETECTION_MINUTES[max(FROZEN_DETECTION_MINUTES)]
 
 
 class TestCheckCoolerFrozen:
@@ -25,76 +40,165 @@ class TestCheckCoolerFrozen:
 
     def test_no_state_coolers_off_returns_false(self, state_path):
         dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
-        assert check_cooler_frozen(dt, False, 25.0, state_path) is False
+        assert check_cooler_frozen(dt, 0, 25.0, state_path) is False
 
-    def test_no_state_coolers_on_starts_tracking(self, state_path):
+    def test_no_state_single_cooler_starts_tracking(self, state_path):
         dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
-        assert check_cooler_frozen(dt, True, 25.0, state_path) is False
+        assert check_cooler_frozen(dt, 1, 25.0, state_path) is False
         state = self._get_state(state_path)
         assert state["cooling_started_at"] == dt.isoformat()
         assert state["cooling_start_temp"] == 25.0
+        assert state["active_cooler_count"] == 1
+
+    def test_no_state_dual_cooler_starts_tracking(self, state_path):
+        dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        assert check_cooler_frozen(dt, 2, 25.0, state_path) is False
+        state = self._get_state(state_path)
+        assert state["active_cooler_count"] == 2
 
     # --- Tracking phase (before detection window) ---
 
-    def test_before_detection_window_returns_false(self, state_path):
+    def test_single_cooler_before_window_returns_false(self, state_path):
         start = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {
             "cooling_started_at": start.isoformat(),
             "cooling_start_temp": 25.0,
+            "active_cooler_count": 1,
         })
-        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES - 1)
-        assert check_cooler_frozen(check_time, True, 25.0, state_path) is False
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[1] - 1)
+        assert check_cooler_frozen(check_time, 1, 25.0, state_path) is False
 
-    # --- Freeze detection ---
-
-    def test_frozen_detected_when_temp_flat(self, state_path):
+    def test_dual_cooler_before_window_returns_false(self, state_path):
         start = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {
             "cooling_started_at": start.isoformat(),
             "cooling_start_temp": 25.0,
+            "active_cooler_count": 2,
         })
-        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES)
-        assert check_cooler_frozen(check_time, True, 25.0, state_path) is True
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2] - 1)
+        assert check_cooler_frozen(check_time, 2, 25.0, state_path) is False
 
-    def test_frozen_detected_when_temp_rising(self, state_path):
+    # --- Freeze detection (dual cooler = 20 min) ---
+
+    def test_dual_frozen_detected_when_temp_flat(self, state_path):
         start = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {
             "cooling_started_at": start.isoformat(),
             "cooling_start_temp": 25.0,
+            "active_cooler_count": 2,
         })
-        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES)
-        assert check_cooler_frozen(check_time, True, 26.0, state_path) is True
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2])
+        assert check_cooler_frozen(check_time, 2, 25.0, state_path) is True
 
-    def test_not_frozen_when_temp_dropping(self, state_path):
+    def test_dual_frozen_detected_when_temp_rising(self, state_path):
         start = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {
             "cooling_started_at": start.isoformat(),
             "cooling_start_temp": 25.0,
+            "active_cooler_count": 2,
         })
-        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES)
-        assert check_cooler_frozen(check_time, True, 24.0, state_path) is False
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2])
+        assert check_cooler_frozen(check_time, 2, 26.0, state_path) is True
+
+    def test_dual_not_frozen_when_temp_dropping(self, state_path):
+        start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        self._set_state(state_path, {
+            "cooling_started_at": start.isoformat(),
+            "cooling_start_temp": 25.0,
+            "active_cooler_count": 2,
+        })
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2])
+        assert check_cooler_frozen(check_time, 2, 24.0, state_path) is False
+
+    # --- Freeze detection (single cooler = 40 min) ---
+
+    def test_single_not_frozen_at_dual_window(self, state_path):
+        """Single cooler should NOT trigger at the dual-cooler window time."""
+        start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        self._set_state(state_path, {
+            "cooling_started_at": start.isoformat(),
+            "cooling_start_temp": 25.0,
+            "active_cooler_count": 1,
+        })
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2])
+        assert check_cooler_frozen(check_time, 1, 25.0, state_path) is False
+
+    def test_single_frozen_detected_at_single_window(self, state_path):
+        start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        self._set_state(state_path, {
+            "cooling_started_at": start.isoformat(),
+            "cooling_start_temp": 25.0,
+            "active_cooler_count": 1,
+        })
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[1])
+        assert check_cooler_frozen(check_time, 1, 25.0, state_path) is True
+
+    def test_single_not_frozen_when_temp_dropping(self, state_path):
+        start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        self._set_state(state_path, {
+            "cooling_started_at": start.isoformat(),
+            "cooling_start_temp": 25.0,
+            "active_cooler_count": 1,
+        })
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[1])
+        assert check_cooler_frozen(check_time, 1, 24.0, state_path) is False
+
+    # --- Cooler count change resets tracking ---
+
+    def test_count_increase_resets_window(self, state_path):
+        """Switching from 1 to 2 coolers should reset the detection window."""
+        start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        self._set_state(state_path, {
+            "cooling_started_at": start.isoformat(),
+            "cooling_start_temp": 25.0,
+            "active_cooler_count": 1,
+        })
+        reset_time = start + datetime.timedelta(minutes=10)
+        assert check_cooler_frozen(reset_time, 2, 24.5, state_path) is False
+        state = self._get_state(state_path)
+        assert state["cooling_started_at"] == reset_time.isoformat()
+        assert state["cooling_start_temp"] == 24.5
+        assert state["active_cooler_count"] == 2
+
+    def test_count_decrease_resets_window(self, state_path):
+        """Switching from 2 to 1 coolers should reset the detection window."""
+        start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        self._set_state(state_path, {
+            "cooling_started_at": start.isoformat(),
+            "cooling_start_temp": 25.0,
+            "active_cooler_count": 2,
+        })
+        reset_time = start + datetime.timedelta(minutes=15)
+        assert check_cooler_frozen(reset_time, 1, 24.0, state_path) is False
+        state = self._get_state(state_path)
+        assert state["active_cooler_count"] == 1
+        assert state["cooling_started_at"] == reset_time.isoformat()
+
+    # --- Window reset on temp drop ---
 
     def test_detection_window_resets_when_temp_drops(self, state_path):
-        """After successful cooling is confirmed the window resets to the new baseline."""
         start = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {
             "cooling_started_at": start.isoformat(),
             "cooling_start_temp": 25.0,
+            "active_cooler_count": 2,
         })
-        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES)
-        check_cooler_frozen(check_time, True, 24.0, state_path)
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2])
+        check_cooler_frozen(check_time, 2, 24.0, state_path)
         state = self._get_state(state_path)
         assert state["cooling_start_temp"] == 24.0
         assert state["cooling_started_at"] == check_time.isoformat()
+        assert state["active_cooler_count"] == 2
 
     def test_frozen_sets_frozen_at_and_clears_tracking(self, state_path):
         start = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {
             "cooling_started_at": start.isoformat(),
             "cooling_start_temp": 25.0,
+            "active_cooler_count": 2,
         })
-        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES)
-        check_cooler_frozen(check_time, True, 25.0, state_path)
+        check_time = start + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2])
+        check_cooler_frozen(check_time, 2, 25.0, state_path)
         state = self._get_state(state_path)
         assert state["frozen_at"] == check_time.isoformat()
         assert "cooling_started_at" not in state
@@ -105,40 +209,37 @@ class TestCheckCoolerFrozen:
         frozen_at = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {"frozen_at": frozen_at.isoformat()})
         check_time = frozen_at + datetime.timedelta(minutes=FROZEN_THAW_MINUTES - 1)
-        assert check_cooler_frozen(check_time, True, 25.0, state_path) is True
+        assert check_cooler_frozen(check_time, 2, 25.0, state_path) is True
 
     def test_thaw_pause_active_ignores_cooler_state(self, state_path):
-        """Even if coolers are off the pause stays active until the window elapses."""
         frozen_at = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {"frozen_at": frozen_at.isoformat()})
         check_time = frozen_at + datetime.timedelta(minutes=10)
-        assert check_cooler_frozen(check_time, False, 20.0, state_path) is True
+        assert check_cooler_frozen(check_time, 0, 20.0, state_path) is True
 
     def test_thaw_pause_ends_after_window(self, state_path):
         frozen_at = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {"frozen_at": frozen_at.isoformat()})
         check_time = frozen_at + datetime.timedelta(minutes=FROZEN_THAW_MINUTES)
-        assert check_cooler_frozen(check_time, True, 25.0, state_path) is False
+        assert check_cooler_frozen(check_time, 2, 25.0, state_path) is False
 
     def test_thaw_pause_clears_frozen_state(self, state_path):
-        """After thaw period with coolers off, state file is cleared."""
         frozen_at = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {"frozen_at": frozen_at.isoformat()})
         check_time = frozen_at + datetime.timedelta(minutes=FROZEN_THAW_MINUTES)
-        check_cooler_frozen(check_time, False, 25.0, state_path)
+        check_cooler_frozen(check_time, 0, 25.0, state_path)
         state = self._get_state(state_path)
         assert "frozen_at" not in state
 
     def test_thaw_pause_starts_tracking_if_coolers_active(self, state_path):
-        """After thaw period with coolers active, tracking starts immediately."""
         frozen_at = datetime.datetime(2024, 1, 1, 12, 0, 0)
         self._set_state(state_path, {"frozen_at": frozen_at.isoformat()})
         check_time = frozen_at + datetime.timedelta(minutes=FROZEN_THAW_MINUTES)
-        check_cooler_frozen(check_time, True, 25.0, state_path)
+        check_cooler_frozen(check_time, 1, 25.0, state_path)
         state = self._get_state(state_path)
         assert "frozen_at" not in state
         assert state["cooling_started_at"] == check_time.isoformat()
-        assert state["cooling_start_temp"] == 25.0
+        assert state["active_cooler_count"] == 1
 
     # --- Cooling stopped ---
 
@@ -147,16 +248,16 @@ class TestCheckCoolerFrozen:
         self._set_state(state_path, {
             "cooling_started_at": start.isoformat(),
             "cooling_start_temp": 25.0,
+            "active_cooler_count": 2,
         })
         check_time = start + datetime.timedelta(minutes=5)
-        assert check_cooler_frozen(check_time, False, 25.0, state_path) is False
+        assert check_cooler_frozen(check_time, 0, 25.0, state_path) is False
         state = self._get_state(state_path)
         assert state.get("cooling_started_at") is None
 
     def test_cooling_stopped_no_tracking_no_write(self, state_path):
-        """When there's no tracking state and coolers are off, no file is written."""
         dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
-        check_cooler_frozen(dt, False, 25.0, state_path)
+        check_cooler_frozen(dt, 0, 25.0, state_path)
         import os
         assert not os.path.exists(state_path)
 
@@ -164,37 +265,55 @@ class TestCheckCoolerFrozen:
 
     def test_missing_state_file_treated_as_empty(self, state_path):
         dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
-        result = check_cooler_frozen(dt, True, 25.0, state_path)
-        assert result is False  # starts tracking
+        result = check_cooler_frozen(dt, 1, 25.0, state_path)
+        assert result is False
 
     def test_corrupt_state_file_treated_as_empty(self, state_path):
         with open(state_path, "w") as f:
             f.write("not json")
         dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
-        result = check_cooler_frozen(dt, True, 25.0, state_path)
-        assert result is False  # starts tracking fresh
+        result = check_cooler_frozen(dt, 1, 25.0, state_path)
+        assert result is False
 
     # --- Full cycle: detect → pause → resume → re-detect ---
 
-    def test_full_freeze_thaw_cycle(self, state_path):
-        """Simulate a complete freeze-detect-thaw-resume cycle."""
+    def test_full_freeze_thaw_cycle_dual(self, state_path):
+        """Full cycle with two coolers active."""
         t0 = datetime.datetime(2024, 1, 1, 0, 0, 0)
 
-        # Cooling starts
-        assert check_cooler_frozen(t0, True, 25.0, state_path) is False
+        # Cooling starts (2 coolers)
+        assert check_cooler_frozen(t0, 2, 25.0, state_path) is False
 
-        # After detection window, temp hasn't dropped → frozen
-        t1 = t0 + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES)
-        assert check_cooler_frozen(t1, True, 25.0, state_path) is True
+        # After dual detection window, temp hasn't dropped → frozen
+        t1 = t0 + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2])
+        assert check_cooler_frozen(t1, 2, 25.0, state_path) is True
 
         # During thaw pause → still paused
         t2 = t1 + datetime.timedelta(minutes=45)
-        assert check_cooler_frozen(t2, False, 25.0, state_path) is True
+        assert check_cooler_frozen(t2, 0, 25.0, state_path) is True
 
         # After thaw period → resume
         t3 = t1 + datetime.timedelta(minutes=FROZEN_THAW_MINUTES)
-        assert check_cooler_frozen(t3, True, 25.0, state_path) is False
+        assert check_cooler_frozen(t3, 2, 25.0, state_path) is False
 
-        # Cooling resumes, starts tracking again
         state = self._get_state(state_path)
         assert state.get("cooling_started_at") == t3.isoformat()
+        assert state.get("active_cooler_count") == 2
+
+    def test_full_freeze_thaw_cycle_single(self, state_path):
+        """Full cycle with one cooler – uses the longer detection window."""
+        t0 = datetime.datetime(2024, 1, 1, 0, 0, 0)
+
+        assert check_cooler_frozen(t0, 1, 25.0, state_path) is False
+
+        # At dual-cooler window time → should NOT detect (single cooler window is longer)
+        t_mid = t0 + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[2])
+        assert check_cooler_frozen(t_mid, 1, 25.0, state_path) is False
+
+        # At single-cooler window → frozen
+        t1 = t0 + datetime.timedelta(minutes=FROZEN_DETECTION_MINUTES[1])
+        assert check_cooler_frozen(t1, 1, 25.0, state_path) is True
+
+        # After thaw period → resume
+        t2 = t1 + datetime.timedelta(minutes=FROZEN_THAW_MINUTES)
+        assert check_cooler_frozen(t2, 1, 25.0, state_path) is False


### PR DESCRIPTION
When Peltier coolers run continuously for 20 minutes without any
temperature drop, the coolant is assumed frozen. All thermal systems
(coolers, heaters, pump, ext fan) are paused for 90 minutes to allow
the coolant to thaw, then normal operation resumes automatically.

Closes #3

https://claude.ai/code/session_01HWVwVvaacBDA1AY4P8WbSs