### PR TITLE
Fix AttributeError in overloaded and data_validity evaluators

### DIFF
--- a/evaluators/data_validity.py
+++ b/evaluators/data_validity.py
@@ -15,6 +15,8 @@ def task(data):
     current_datetime = datetime.datetime.now()
     result = {}
     for device_type, mapper in data.items():
+        if not isinstance(mapper, dict):
+            continue
         for v, entry in mapper.items():
             for alias, device_data in entry.items():
                 validity = _is_valid(current_datetime, device_data)

--- a/evaluators/overloaded.py
+++ b/evaluators/overloaded.py
@@ -14,6 +14,8 @@ def task(data):
     current_datetime = datetime.datetime.now()
     result = {}
     for device_type, mapper in data.items():
+        if not isinstance(mapper, dict):
+            continue
         for v, entry in mapper.items():
             for alias, device_data in entry.items():
                 overloaded = _is_overloaded(current_datetime, device_data)

--- a/tests/test_evaluators/test_data_validity.py
+++ b/tests/test_evaluators/test_data_validity.py
@@ -59,3 +59,14 @@ class TestDataValidity:
         result = task(data)
         # No devices to evaluate, so result is empty
         assert result == {}
+
+    def test_skips_non_dict_top_level_values(self):
+        """Non-dict top-level values like cooler_frozen should be skipped."""
+        now = datetime.datetime.now()
+        data = {
+            "cooler_frozen": True,
+            "meters": {"v0": {"M1": {"Datetime": now}}},
+            "plugs": {"v0": {}},
+        }
+        result = task(data)
+        assert result["meters"]["v0"]["M1"]["Valid"] is True

--- a/tests/test_evaluators/test_overloaded.py
+++ b/tests/test_evaluators/test_overloaded.py
@@ -33,3 +33,15 @@ class TestOverloaded:
         result = task(data)
         # No devices to evaluate, so result is empty
         assert result == {}
+
+    def test_skips_non_dict_top_level_values(self):
+        """Non-dict top-level values like cooler_frozen should be skipped."""
+        data = {
+            "cooler_frozen": True,
+            "plugs": {"v0": {
+                "P1": {"Code": "0b", "Datetime": datetime.datetime.now()},
+            }},
+            "meters": {"v0": {}},
+        }
+        result = task(data)
+        assert result["plugs"]["v0"]["P1"]["IsOverloaded"] is True


### PR DESCRIPTION
The cooler freeze detection feature adds a top-level "cooler_frozen"
boolean to the data dict. Evaluators that iterate all data.items()
and assume every value is a nested dict crash when they hit this bool.
Skip non-dict values in both overloaded.py and data_validity.py.

https://claude.ai/code/session_01SBfc2cgW9tUimkicqorQgR