### PR TITLE
Log stack trace on fatal crash

### DIFF
--- a/nepenthes.py
+++ b/nepenthes.py
@@ -89,4 +89,8 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        logger.exception("Fatal crash")
+        raise


### PR DESCRIPTION
Wrap main() in try/except so unhandled exceptions are written to the
log file via logger.exception() before re-raising.  Previously a crash
in _process() or elsewhere in the main loop would only print to stderr
and never appear in the rotated log files.

https://claude.ai/code/session_01A5cEto1kr5oWvtQSuMnQqU