### PR TITLE
Temporarily disable cooler freeze detection

### DIFF
--- a/config/desired_states.py
+++ b/config/desired_states.py
@@ -31,6 +31,8 @@ desired_temperature_map = {
 # Shared thresholds for staged cooling.  Both coolers use the same levels so
 # that neither is systematically preferred.  The evaluator alternates which
 # cooler is "primary" (activated first) each session to balance wear.
+COOLER_FREEZE_DETECTION_ENABLED = False  # Temporarily disabled
+
 COOLER_PRIMARY_THRESHOLD = 0.0   # Activate the primary cooler
 COOLER_SECONDARY_THRESHOLD = -0.5  # Activate both coolers
 

--- a/evaluators/cooler_heater.py
+++ b/evaluators/cooler_heater.py
@@ -81,9 +81,9 @@ def evaluate_desired_cooler_states(current_datetime: datetime.datetime, data):
     pre_max_diff_temp = min(list(air_meter_desired_diffs.values())) # Positive = should warm, Negative = should cool
     logger.debug("Temperatures: %s, desired_diffs: %s, pre_max_diff_temp: %.1f", temperatures, air_meter_desired_diffs, pre_max_diff_temp)
 
-    # Detect cooler frozen condition
+    # Detect cooler frozen condition (temporarily disabled)
     active_cooler_count = sum(1 for alias in cooler_aliases if pump_element_switch_states.get(alias, False))
-    frozen_paused = check_cooler_frozen(current_datetime, active_cooler_count, max_temperature)
+    frozen_paused = False  # check_cooler_frozen(current_datetime, active_cooler_count, max_temperature)
 
     if frozen_paused:
         desired_humidity = desired_min_humidity(current_datetime)

--- a/evaluators/cooler_heater.py
+++ b/evaluators/cooler_heater.py
@@ -8,7 +8,7 @@ from helpers.extract_data import extract_humidities, extract_temperatures, extra
     extract_pump_element_switch_states, extract_current_humidity
 from config.desired_states import desired_temperature, desired_min_humidity,\
     desired_temperature_map, COOLER_PRIMARY_THRESHOLD, COOLER_SECONDARY_THRESHOLD,\
-    heater_active_diff_thresholds, ext_fan_diff_thresholds
+    heater_active_diff_thresholds, ext_fan_diff_thresholds, COOLER_FREEZE_DETECTION_ENABLED
 from helpers.cooler_balance import get_primary_cooler, rotate_primary_cooler, DEFAULT_STATE_PATH
 from helpers.cooler_frozen import check_cooler_frozen
 
@@ -81,9 +81,9 @@ def evaluate_desired_cooler_states(current_datetime: datetime.datetime, data):
     pre_max_diff_temp = min(list(air_meter_desired_diffs.values())) # Positive = should warm, Negative = should cool
     logger.debug("Temperatures: %s, desired_diffs: %s, pre_max_diff_temp: %.1f", temperatures, air_meter_desired_diffs, pre_max_diff_temp)
 
-    # Detect cooler frozen condition (temporarily disabled)
+    # Detect cooler frozen condition
     active_cooler_count = sum(1 for alias in cooler_aliases if pump_element_switch_states.get(alias, False))
-    frozen_paused = False  # check_cooler_frozen(current_datetime, active_cooler_count, max_temperature)
+    frozen_paused = check_cooler_frozen(current_datetime, active_cooler_count, max_temperature) if COOLER_FREEZE_DETECTION_ENABLED else False
 
     if frozen_paused:
         desired_humidity = desired_min_humidity(current_datetime)

--- a/tests/test_evaluator_pipeline.py
+++ b/tests/test_evaluator_pipeline.py
@@ -84,7 +84,7 @@ class TestEvaluatorPipeline:
         assert "plugs" in result
         assert "should_heartbeat" in result
 
-    @pytest.mark.skip(reason="Cooler freeze detection temporarily disabled")
+    @patch("evaluators.cooler_heater.COOLER_FREEZE_DETECTION_ENABLED", True)
     @patch("evaluators.cooler_heater.check_cooler_frozen", return_value=True)
     def test_pipeline_with_cooler_frozen(self, mock_frozen, full_data):
         """Pipeline completes when cooler_frozen injects a top-level bool.
@@ -98,7 +98,7 @@ class TestEvaluatorPipeline:
         assert result["cooler_frozen"] is True
         assert "should_heartbeat" in result
 
-    @pytest.mark.skip(reason="Cooler freeze detection temporarily disabled")
+    @patch("evaluators.cooler_heater.COOLER_FREEZE_DETECTION_ENABLED", True)
     @patch("evaluators.cooler_heater.check_cooler_frozen", return_value=True)
     def test_overloaded_detected_despite_frozen(self, mock_frozen, full_data):
         """Overload detection still works when cooler_frozen is present."""

--- a/tests/test_evaluator_pipeline.py
+++ b/tests/test_evaluator_pipeline.py
@@ -84,6 +84,7 @@ class TestEvaluatorPipeline:
         assert "plugs" in result
         assert "should_heartbeat" in result
 
+    @pytest.mark.skip(reason="Cooler freeze detection temporarily disabled")
     @patch("evaluators.cooler_heater.check_cooler_frozen", return_value=True)
     def test_pipeline_with_cooler_frozen(self, mock_frozen, full_data):
         """Pipeline completes when cooler_frozen injects a top-level bool.
@@ -97,6 +98,7 @@ class TestEvaluatorPipeline:
         assert result["cooler_frozen"] is True
         assert "should_heartbeat" in result
 
+    @pytest.mark.skip(reason="Cooler freeze detection temporarily disabled")
     @patch("evaluators.cooler_heater.check_cooler_frozen", return_value=True)
     def test_overloaded_detected_despite_frozen(self, mock_frozen, full_data):
         """Overload detection still works when cooler_frozen is present."""

--- a/tests/test_evaluators/test_cooler_heater.py
+++ b/tests/test_evaluators/test_cooler_heater.py
@@ -249,6 +249,7 @@ class TestEvaluateDesiredCoolerStates:
         assert result["cooler_frozen"] is False
 
 
+@pytest.mark.skip(reason="Cooler freeze detection temporarily disabled")
 class TestEvaluateDesiredCoolerStatesFrozen:
     """Tests for the cooler-frozen override path."""
 

--- a/tests/test_evaluators/test_cooler_heater.py
+++ b/tests/test_evaluators/test_cooler_heater.py
@@ -249,7 +249,7 @@ class TestEvaluateDesiredCoolerStates:
         assert result["cooler_frozen"] is False
 
 
-@pytest.mark.skip(reason="Cooler freeze detection temporarily disabled")
+@patch("evaluators.cooler_heater.COOLER_FREEZE_DETECTION_ENABLED", True)
 class TestEvaluateDesiredCoolerStatesFrozen:
     """Tests for the cooler-frozen override path."""
 


### PR DESCRIPTION
Bypass the check_cooler_frozen() call in the cooler_heater evaluator
so the system no longer enters freeze-thaw pause cycles. Related
tests are skipped until the feature is re-enabled.

https://claude.ai/code/session_01KFWXSr6xScfXtZk3ha6Ytd