### PR TITLE
Re-enable freeze detection, swap meter temps, fix ext fan offset

### DIFF
--- a/config/desired_states.py
+++ b/config/desired_states.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 
 desired_temperature_map = {
-    "N. Meter 2": sorted([
+    "N. Meter 1": sorted([
         (datetime.time( 2, 0 , 0), 12.5),
         (datetime.time( 4, 30, 0), 12.0),
         (datetime.time( 5, 0 , 0), 12.0),
@@ -17,7 +17,7 @@ desired_temperature_map = {
         (datetime.time(16, 0 , 0), 17.0),
         (datetime.time(23, 0 , 0), 13.5)
         ], key=lambda x: x[0]),
-    "N. Meter 1": sorted([
+    "N. Meter 2": sorted([
         (datetime.time( 3, 30, 0), 15.0),
         (datetime.time( 6,  0, 0), 18.0),
         (datetime.time( 9,  0, 0), 25.0),
@@ -31,7 +31,7 @@ desired_temperature_map = {
 # Shared thresholds for staged cooling.  Both coolers use the same levels so
 # that neither is systematically preferred.  The evaluator alternates which
 # cooler is "primary" (activated first) each session to balance wear.
-COOLER_FREEZE_DETECTION_ENABLED = False  # Temporarily disabled
+COOLER_FREEZE_DETECTION_ENABLED = True
 
 COOLER_PRIMARY_THRESHOLD = 0.0   # Activate the primary cooler
 COOLER_SECONDARY_THRESHOLD = -0.5  # Activate both coolers

--- a/evaluators/cooler_heater.py
+++ b/evaluators/cooler_heater.py
@@ -117,9 +117,10 @@ def evaluate_desired_cooler_states(current_datetime: datetime.datetime, data):
     logger.debug("ExtFan desired: %s", extfan_desired_state)
 
     # When External fan is on, actual temperature is perceived lower than actual
-    # Should try to turn cooler on by lowering max_diff_temp
-    ext_fan_is_on =  any(extfan_desired_state.values())
-    max_diff_temp = pre_max_diff_temp - (1.0 if ext_fan_is_on else 0.0)
+    # Only apply offset when already in cooling territory to avoid activating
+    # coolers when temperature is at or below desired
+    ext_fan_is_on = any(extfan_desired_state.values())
+    max_diff_temp = pre_max_diff_temp - (1.0 if ext_fan_is_on and pre_max_diff_temp <= COOLER_PRIMARY_THRESHOLD else 0.0)
 
     # Decide pump-safe Cooler and Heater state
     cooler_prime_desired_state = get_balanced_cooler_desired_state(max_diff_temp, pump_element_switch_states)


### PR DESCRIPTION
## Summary
- **Re-enable freeze detection** behind `COOLER_FREEZE_DETECTION_ENABLED` config flag (set to `True`)
- **Swap desired temperature schedules** between N. Meter 1 (now 12.0–24.0 range) and N. Meter 2 (now 15.0–25.0 range)
- **Fix ext fan cooler offset bug** — the `-1.0` temperature offset was applied unconditionally when the external fan was on (including time-scheduled activation), which could flip a "should warm" signal into a "should cool" signal, activating both coolers even when temperature was below desired. The offset now only applies when the system is already in cooling territory (`pre_max_diff_temp <= COOLER_PRIMARY_THRESHOLD`).

## Test plan
- [x] All 329 tests pass with 100% coverage
- [ ] Verify coolers do not activate when temperature is below desired with ext fan on
- [ ] Verify freeze detection triggers correctly when enabled

https://claude.ai/code/session_01KFWXSr6xScfXtZk3ha6Ytd